### PR TITLE
Exclude _app.js from babelTransformContext

### DIFF
--- a/lib/babelTransformContext.js
+++ b/lib/babelTransformContext.js
@@ -1,3 +1,4 @@
+const { basename } = require('path');
 const { annotateAsPure } = require('./astUtils');
 
 /**
@@ -161,6 +162,8 @@ module.exports = function (babel, options) {
 
         if (isApiRoute) {
           visitApiHandler(babel, path);
+        } else if (basename(filename).startsWith('_app.')) {
+          return;
         } else {
           visitPage(babel, path);
         }

--- a/lib/babelTransformContext.js
+++ b/lib/babelTransformContext.js
@@ -159,12 +159,12 @@ module.exports = function (babel, options) {
 
         const { filename } = this.file.opts;
         const isApiRoute = filename && filename.startsWith(apiDir);
+        const isAppComponent =
+          filename && basename(filename).startsWith('_app.');
 
         if (isApiRoute) {
           visitApiHandler(babel, path);
-        } else if (basename(filename).startsWith('_app.')) {
-          return;
-        } else {
+        } else if (!isAppComponent) {
           visitPage(babel, path);
         }
       },


### PR DESCRIPTION
Hey, awesome concept on this library! I don't know if I should raise an issue first (made a fix that works), but basically, my issue is the following:

If I enable the experimental context stuff, my `_app.tsx` (the only non-vanilla thing it's doing is adding in some CSS and an error boundary), my entire app breaks with a `call stack exceeded error` on `_app.tsx`. No more error context at all. After hours of debugging I could not understand what was going on so I just went disabling things one by one. Disabling the experimental context flag fixed it.

Looking through the code I figured that if I excluded the `_app.tsx` from `babelTransformContext` the library would still work (context and all, I'm using cookie auth and it works great). However, I don't know the underlying implications of this exactly. From what I understand and tested, disabling here just makes `req, res` undefined on requests made from `_app.tsx`. For my use case, not having that is not a deal-breaker. Until contexts are reworked, we could just disable `_app.tsx` handling.

Let me know if I can help any other way.
