### PR TITLE
Adds HTTP status code 500 for errors that are throw.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -41,6 +41,9 @@ function createRpcFetcher(url, method) {
       },
     })
       .then(function (res) {
+        if (res.status === 500) {
+          return res.json();
+        }
         if (!res.ok) {
           throw new Error('Unexpected HTTP status ' + res.status);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,7 +36,7 @@ function createRpcHandler(methodsInit) {
           message = `Invalid value thrown in "${method}", must be instance of Error`,
           stack = undefined,
         } = error instanceof Error ? error : {};
-        return res.json({
+        return res.status(500).json({
           error: {
             name,
             message,


### PR DESCRIPTION
It's probably logical for failed RPC calls to have a bad status code. So this PR uses HTTP 500, if the function throws an error.

- Tests pass
- Fixes https://github.com/Janpot/next-rpc/issues/19

This makes failed calls stand out much easier in the browser dev tools too!

Also, love the library, exactly what I was looking for! ❤️ 