### PR TITLE
Use custom `findPagesDir` function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -83,25 +83,23 @@ export default function init(withRpcConfig: WithRpcConfig = {}) {
   };
 }
 
-
-
 // taken from https://github.com/vercel/next.js/blob/v12.1.5/packages/next/lib/find-pages-dir.ts
 export function findPagesDir(dir: string): string {
   // prioritize ./pages over ./src/pages
-  let curDir = path.join(dir, 'pages')
-  if (fs.existsSync(curDir)) return curDir
+  let curDir = path.join(dir, 'pages');
+  if (fs.existsSync(curDir)) return curDir;
 
-  curDir = path.join(dir, 'src/pages')
-  if (fs.existsSync(curDir)) return curDir
+  curDir = path.join(dir, 'src/pages');
+  if (fs.existsSync(curDir)) return curDir;
 
   // Check one level up the tree to see if the pages directory might be there
   if (fs.existsSync(path.join(dir, '..', 'pages'))) {
-      throw new Error(
-          'No `pages` directory found. Did you mean to run `next` in the parent (`../`) directory?',
-      )
+    throw new Error(
+      'No `pages` directory found. Did you mean to run `next` in the parent (`../`) directory?'
+    );
   }
 
   throw new Error(
-      "Couldn't find a `pages` directory. Please create one under the project root",
-  )
+    "Couldn't find a `pages` directory. Please create one under the project root"
+  );
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
-import { findPagesDir } from 'next/dist/lib/find-pages-dir';
 import * as path from 'path';
+import * as fs from 'fs';
 import * as webpack from 'webpack';
 import { NextConfig } from 'next';
 import { PluginOptions as RpcPluginOptions } from './babelTransformRpc';
@@ -81,4 +81,27 @@ export default function init(withRpcConfig: WithRpcConfig = {}) {
       },
     };
   };
+}
+
+
+
+// taken from https://github.com/vercel/next.js/blob/v12.1.5/packages/next/lib/find-pages-dir.ts
+export function findPagesDir(dir: string): string {
+  // prioritize ./pages over ./src/pages
+  let curDir = path.join(dir, 'pages')
+  if (fs.existsSync(curDir)) return curDir
+
+  curDir = path.join(dir, 'src/pages')
+  if (fs.existsSync(curDir)) return curDir
+
+  // Check one level up the tree to see if the pages directory might be there
+  if (fs.existsSync(path.join(dir, '..', 'pages'))) {
+      throw new Error(
+          'No `pages` directory found. Did you mean to run `next` in the parent (`../`) directory?',
+      )
+  }
+
+  throw new Error(
+      "Couldn't find a `pages` directory. Please create one under the project root",
+  )
 }


### PR DESCRIPTION
`findPagesDir` in latest next returns an object instead of a path and will probably continue to break in the future, i vendored it in the code

Fix #38